### PR TITLE
Fix reloader deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,14 @@ gemfile:
   - Gemfile.rails41
   - Gemfile.rails42
   - Gemfile.rails50 # Min ruby 2.2.2
+  - Gemfile.rails51 # Min ruby 2.2.2
 matrix:
   exclude:
     - rvm: 2.0.0
       gemfile: Gemfile.rails50
+    - rvm: 2.0.0
+      gemfile: Gemfile.rails51
     - rvm: 2.1.7
       gemfile: Gemfile.rails50
+    - rvm: 2.1.7
+      gemfile: Gemfile.rails51

--- a/Gemfile.rails51
+++ b/Gemfile.rails51
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gemspec
+
+gem 'rails', '~> 5.1.0.rc1'
+gem 'mime-types', '~> 2.99.3'
+gem 'rails-controller-testing'

--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -424,7 +424,7 @@ module Apipie
     # as this would break loading of the controllers.
     def rails_mark_classes_for_reload
       unless Rails.application.config.cache_classes
-        Rails.application.reloader.cleanup!
+        Rails.application.reloader.reload!
         init_env
         reload_examples
         Rails.application.reloader.prepare!

--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -424,10 +424,10 @@ module Apipie
     # as this would break loading of the controllers.
     def rails_mark_classes_for_reload
       unless Rails.application.config.cache_classes
-        ActionDispatch::Reloader.cleanup!
+        Rails.application.reloader.cleanup!
         init_env
         reload_examples
-        ActionDispatch::Reloader.prepare!
+        Rails.application.reloader.prepare!
       end
     end
 


### PR DESCRIPTION
ActionDispatch::Reloader.cleanup! and ActionDispatch::Reloader.prepare! are deprecated in Rails 5.1.0.rc1
https://github.com/rails/rails/blob/v5.0.2/actionpack/lib/action_dispatch/middleware/reloader.rb#L48
